### PR TITLE
Read only function to determine device size.

### DIFF
--- a/I2C_eeprom.cpp
+++ b/I2C_eeprom.cpp
@@ -304,6 +304,32 @@ uint32_t I2C_eeprom::determineSize(const bool debug)
   return 0;
 }
 
+uint32_t I2C_eeprom::determineSizeNoWrite()
+{
+    // try to read a byte to see if connected
+    if (!isConnected()) return 0;
+
+    bool addressSize = _isAddressSizeTwoWords;
+    byte dummyVal = 0;
+    uint32_t lastOkSize = 0;
+
+    for (uint32_t size = 128; size <= 65536; size *= 2)
+    {
+        _isAddressSizeTwoWords = size > I2C_DEVICESIZE_24LC16;  // 2048
+
+        //Try to read last byte of the block, should return lenght of 0 when fails
+        if (readBlock(size - 1, &dummyVal, 1) == 0)
+        {
+            _isAddressSizeTwoWords = addressSize;
+            break;
+        }
+        else
+        {
+            lastOkSize = size;
+        }
+    }
+    return lastOkSize;
+}
 
 uint32_t I2C_eeprom::getDeviceSize()
 {

--- a/I2C_eeprom.h
+++ b/I2C_eeprom.h
@@ -104,6 +104,7 @@ public:
 
   //  Meta data functions
   uint32_t determineSize(const bool debug = false);
+  uint32_t determineSizeNoWrite();
   uint32_t getDeviceSize();
   uint8_t  getPageSize();
   uint8_t  getPageSize(uint32_t deviceSize);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=I2C_EEPROM
-version=1.8.0
+version=1.8.1
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library for I2C EEPROMS


### PR DESCRIPTION
Added read-only function to determine device size. This to prevent unnecessary device writes and possibility that data is changed during a test failure.