### PR TITLE
doc: update vcc schematic

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ before calling **I2C_eeprom.begin()**.
 
 ```cpp
         +---U---+
-    A0  | 1   8 |  VCC = +5V
+    A0  | 1   8 |  VCC = 1.7V to 5.5V
     A1  | 2   7 |   WP = write protect pin
     A2  | 3   6 |  SCL = I2C clock
    GND  | 4   5 |  SDA = I2C data
         +-------+
 
-default address = 0x50 .. 0x57 depending on three address lines
+Default address = 0x50 .. 0x57 depending on three address lines (A0, A1, A2).
 ```
 
 


### PR DESCRIPTION
According to https://ww1.microchip.com/downloads/en/DeviceDoc/AT24C64D-I2C-Compatible-2-Wire-Serial-EEPROM-64-Kbit-20005937B.pdf the range for vcc is 1.7V to 5.5V.