### PR TITLE
Fix #70, increase internal lengths allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.8.4] - 2024-04-20
 - Fix #70, increase length internal buffer.
-- add compile time flag **EN_AUTO_WRITE_PROTECT**
+- add compile time flag **EN_AUTO_WRITE_PROTECT** (thanks to microfoundry)
 - improve readability: cnt => count  addr => address
 - add URL to examples
 - minor edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [1.8.4] - 2024-04-20
+- Fix #70, increase length internal buffer.
+- add compile time flag **EN_AUTO_WRITE_PROTECT**
+- improve readability: cnt => count  addr => address
+- add URL to examples
+- minor edits.
+
+
 ## [1.8.3] - 2024-03-28
 - Fix #64, compiler warning.
 - add **verifyBlock(memoryAddress, buffer, length)**
@@ -14,7 +22,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - update keywords.txt
 - update examples
 - update readme.md
-
 
 ## [1.8.2] - 2024-01-02
 - updated **uint32_t determineSizeNoWrite()**, kudos to roelandkluit

--- a/I2C_eeprom.h
+++ b/I2C_eeprom.h
@@ -171,11 +171,11 @@ private:
   //  TODO incrBuffer is an implementation name, not a functional name.
   int      _pageBlock(const uint16_t memoryAddress, const uint8_t * buffer, const uint16_t length, const bool incrBuffer);
   //  returns I2C status, 0 = OK
-  int      _WriteBlock(const uint16_t memoryAddress, const uint8_t * buffer, const uint8_t length);
+  int      _WriteBlock(const uint16_t memoryAddress, const uint8_t * buffer, const uint16_t length);
   //  returns bytes read.
-  uint8_t  _ReadBlock(const uint16_t memoryAddress, uint8_t * buffer, const uint8_t length);
+  uint8_t  _ReadBlock(const uint16_t memoryAddress, uint8_t * buffer, const uint16_t length);
   //  compare bytes in EEPROM.
-  bool     _verifyBlock(const uint16_t memoryAddress, const uint8_t * buffer, const uint8_t length);
+  bool     _verifyBlock(const uint16_t memoryAddress, const uint8_t * buffer, const uint16_t length);
 
   //  to optimize the write latency of the EEPROM
   void     _waitEEReady();

--- a/I2C_eeprom.h
+++ b/I2C_eeprom.h
@@ -2,16 +2,16 @@
 //
 //    FILE: I2C_eeprom.h
 //  AUTHOR: Rob Tillaart
-// VERSION: 1.8.3
+// VERSION: 1.8.4
 // PURPOSE: Arduino Library for external I2C EEPROM 24LC256 et al.
-//     URL: https://github.com/RobTillaart/I2C_EEPROM.git
+//     URL: https://github.com/RobTillaart/I2C_EEPROM
 
 
 #include "Arduino.h"
 #include "Wire.h"
 
 
-#define I2C_EEPROM_VERSION          (F("1.8.3"))
+#define I2C_EEPROM_VERSION          (F("1.8.4"))
 
 #define I2C_DEVICESIZE_24LC512      65536
 #define I2C_DEVICESIZE_24LC256      32768
@@ -32,6 +32,15 @@
 #ifndef I2C_WRITEDELAY
 #define I2C_WRITEDELAY              5000
 #endif
+
+
+//  set the flag EN_AUTO_WRITE_PROTECT to 1 to enable the Write Control at compile time 
+//  used if the write_protect pin is explicitly set in the begin() function.
+//  the flag can be set as command line option.
+#ifndef EN_AUTO_WRITE_PROTECT
+#define EN_AUTO_WRITE_PROTECT       0
+#endif
+
 
 #ifndef UNIT_TEST_FRIEND
 #define UNIT_TEST_FRIEND
@@ -176,7 +185,7 @@ private:
   bool     _debug = false;
 
   int8_t   _writeProtectPin = -1;
-  bool     _autoWriteProtect = false;
+  bool     _autoWriteProtect = EN_AUTO_WRITE_PROTECT;
 
   UNIT_TEST_FRIEND;
 };

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Arduino Library for external I2C EEPROM - 24LC512, 24LC256, 24LC64/32/16/08/04/0
 This library is to access external I2C EEPROM up to 64KB (= 512 Kbit) in size.
 MicroChip 24LC512, 24LC256, 24LC64, 24LC32, 24LC16, 24LC08, 24LC04, 24LC02, 24LC01 and equivalents.
 
+Also confirmed working M24512-W, M24512-R, M24512-DF (See #68). 
+Not supported is the identification page functions.
 
 The **I2C_eeprom_cyclic_store** interface is documented [here](README_cyclic_store.md)
 

--- a/examples/I2C_eeprom_cyclic_store/I2C_eeprom_cyclic_store.ino
+++ b/examples/I2C_eeprom_cyclic_store/I2C_eeprom_cyclic_store.ino
@@ -3,20 +3,20 @@
 //  AUTHOR: Tomas Hübner
 // VERSION: 1.0.0
 // PURPOSE: Simple example of how to use cyclic storage.
-//
+//     URL: https://github.com/RobTillaart/I2C_EEPROM
 
 
 #include <I2C_eeprom.h>
 #include <I2C_eeprom_cyclic_store.h>
 
-#define MEMORY_SIZE 0x2000 // Total capacity of the EEPROM
-#define PAGE_SIZE 64 // Size of write page of device, use datasheet to find!
+#define MEMORY_SIZE 8192      //  Total capacity of the EEPROM (8K == 8192 == 0x2000)
+#define PAGE_SIZE 64          //  Size of write page of device, use datasheet to find!
 
 
 struct SampleData {
 public:
   uint32_t counter;
-  // Must use fixed length string, avoid using the String class.
+  //  Must use fixed length string, avoid using the String class.
   char message[32];
 };
 

--- a/examples/I2C_eeprom_determineSize/I2C_eeprom_determineSize.ino
+++ b/examples/I2C_eeprom_determineSize/I2C_eeprom_determineSize.ino
@@ -2,6 +2,7 @@
 //    FILE: I2C_eeprom_determineSize.ino
 //  AUTHOR: Rob Tillaart
 // PURPOSE: test determinSize() function
+//     URL: https://github.com/RobTillaart/I2C_EEPROM
 
 
 #include "Wire.h"
@@ -34,7 +35,7 @@ void setup()
   delay(10);
 
   start = micros();
-  uint32_t size = ee.determineSize(false);  // debug param
+  uint32_t size = ee.determineSize(false);  //  debug parameter
   diff = micros() - start;
   Serial.print("TIME: ");
   Serial.print(diff);
@@ -70,5 +71,5 @@ void loop()
 }
 
 
-// -- END OF FILE --
+//  -- END OF FILE --
 

--- a/examples/I2C_eeprom_determineSizeNoWrite/I2C_eeprom_determineSizeNoWrite.ino
+++ b/examples/I2C_eeprom_determineSizeNoWrite/I2C_eeprom_determineSizeNoWrite.ino
@@ -2,6 +2,7 @@
 //    FILE: I2C_eeprom_determineSizeNoWrite.ino
 //  AUTHOR: Rob Tillaart
 // PURPOSE: test determineSizeNoWrite() function
+//     URL: https://github.com/RobTillaart/I2C_EEPROM
 
 
 #include "Wire.h"

--- a/examples/I2C_eeprom_format/I2C_eeprom_format.ino
+++ b/examples/I2C_eeprom_format/I2C_eeprom_format.ino
@@ -2,6 +2,7 @@
 //    FILE: I2C_eeprom_format.ino
 //  AUTHOR: Rob Tillaart
 // PURPOSE: demo format EEPROM
+//     URL: https://github.com/RobTillaart/I2C_EEPROM
 
 
 #include "Wire.h"
@@ -32,7 +33,7 @@ void setup()
 
 
   Serial.println();
-  uint32_t size = ee.determineSize(false);  // debug param
+  uint32_t size = ee.determineSize(false);  //  debug parameter
   if (size == 0)
   {
     Serial.println("SIZE: could not determine size");
@@ -85,4 +86,4 @@ void loop()
 }
 
 
-// -- END OF FILE --
+//  -- END OF FILE --

--- a/examples/I2C_eeprom_struct/I2C_eeprom_struct.ino
+++ b/examples/I2C_eeprom_struct/I2C_eeprom_struct.ino
@@ -2,9 +2,10 @@
 //    FILE: I2C_eeprom_struct.ino
 //  AUTHOR: Rob Tillaart
 // PURPOSE: demo I2C_EEPROM library store /retrieve struct
+//     URL: https://github.com/RobTillaart/I2C_EEPROM
 //
-// uses a 24LC256 (32KB) EEPROM
-// as this test writes a lot it might wear out EEPROMs eventually.
+//  uses a 24LC256 (32KB) EEPROM
+//  as this test writes a lot it might wear out EEPROMs eventually.
 //
 
 
@@ -44,15 +45,15 @@ void setup()
   Serial.print("size: \t");
   Serial.println(sizeof(measurement));
 
-  // clear EEPROM part
+  //  clear EEPROM part
   ee.setBlock(0, 0, sizeof(measurement));
 
-  // make measurement here
+  //  make measurement here
   measurement.temperature = 22.5;
   measurement.humidity    = 53.1;
   measurement.pressure    = 1000.9;
 
-  // store it in EEPROM
+  //  store it in EEPROM
   start = micros();
   ee.writeBlock(0, (uint8_t *) &measurement, sizeof(measurement));
   duration = micros() - start;
@@ -60,12 +61,12 @@ void setup()
   Serial.println(duration);
   delay(10);
 
-  // clear measurement struct
+  //  clear measurement struct
   measurement.temperature = 0;
   measurement.humidity    = 0;
   measurement.pressure    = 0;
 
-  // retrieve old measurement
+  //  retrieve old measurement
   start = micros();
   ee.readBlock(0, (uint8_t *) &measurement, sizeof(measurement));
   duration = micros() - start;
@@ -89,5 +90,5 @@ void loop()
 }
 
 
-// -- END OF FILE
+//  -- END OF FILE
 

--- a/examples/I2C_eeprom_test/I2C_eeprom_test.ino
+++ b/examples/I2C_eeprom_test/I2C_eeprom_test.ino
@@ -2,18 +2,19 @@
 //    FILE: I2C_eeprom_test.ino
 //  AUTHOR: Rob Tillaart
 // PURPOSE: show/test I2C_EEPROM library
+//     URL: https://github.com/RobTillaart/I2C_EEPROM
 //
-// uses a 24LC256 (32KB) EEPROM
-// might need adaptions for other EEPROMS (page size etc)
+//  uses a 24LC256 (32KB) EEPROM
+//  might need adaptions for other EEPROMS (page size etc)
 
 
 #include "Wire.h"
 #include "I2C_eeprom.h"
 
 
-// UNO
+//  UNO
 #define SERIAL_OUT Serial
-// Due
+//  Due
 // #define SERIAL_OUT SerialUSB
 
 
@@ -247,5 +248,5 @@ void dumpEEPROM(uint16_t memoryAddress, uint16_t length)
 }
 
 
-// -- END OF FILE --
+//  -- END OF FILE --
 

--- a/examples/I2C_eeprom_test_performance/I2C_eeprom_test_performance.ino
+++ b/examples/I2C_eeprom_test_performance/I2C_eeprom_test_performance.ino
@@ -2,6 +2,7 @@
 //    FILE: I2C_eeprom_test_performance.ino
 //  AUTHOR: Rob Tillaart
 // PURPOSE: test I2C_EEPROM library
+//     URL: https://github.com/RobTillaart/I2C_EEPROM
 
 
 #include "Wire.h"
@@ -94,7 +95,7 @@ void test()
   Serial.println(totals);
   totals = 0;
 
-  // same tests but now with a 5 millisec delay in between.
+  //  same tests but now with a 5 milliseconds delay in between.
   delay(5);
 
   Serial.print("\nTEST: timing writeByte()\t");
@@ -180,5 +181,5 @@ void dumpEEPROM(uint16_t memoryAddress, uint16_t length)
 }
 
 
-// -- END OF FILE --
+//  -- END OF FILE --
 

--- a/examples/I2C_eeprom_update/I2C_eeprom_update.ino
+++ b/examples/I2C_eeprom_update/I2C_eeprom_update.ino
@@ -2,8 +2,9 @@
 //    FILE: I2C_eeprom_update.ino
 //  AUTHOR: Rob Tillaart
 // PURPOSE: demo I2C_EEPROM library - updateByte
+//     URL: https://github.com/RobTillaart/I2C_EEPROM
 //
-// uses a 24LC256 (32KB) EEPROM
+//  uses a 24LC256 (32KB) EEPROM
 
 
 #include "Wire.h"
@@ -52,7 +53,7 @@ void setup()
 
   Serial.println("\nTEST: 100x writebyte()");
   delay(10);
-  ee.setBlock(0, 0, 100);  // clear first 100 bytes
+  ee.setBlock(0, 0, 100);  //  clear first 100 bytes
   start = micros();
   for (int i = 0; i < 100; i++)
   {
@@ -64,7 +65,7 @@ void setup()
   delay(10);
 
   Serial.println("\nTEST: 100x updateByte()");
-  ee.setBlock(0, 0, 100);  // clear first 100 bytes
+  ee.setBlock(0, 0, 100);  //  clear first 100 bytes
   start = micros();
   for (int i = 0; i < 100; i++)
   {
@@ -84,5 +85,5 @@ void loop()
 }
 
 
-// -- END OF FILE --
+//  -- END OF FILE --
 

--- a/examples/I2C_eeprom_updateBlock/I2C_eeprom_updateBlock.ino
+++ b/examples/I2C_eeprom_updateBlock/I2C_eeprom_updateBlock.ino
@@ -2,6 +2,7 @@
 //    FILE: I2C_eeprom_updateBlock.ino
 //  AUTHOR: Rob Tillaart
 // PURPOSE: demo I2C_EEPROM library - performance gain updateBlock
+//     URL: https://github.com/RobTillaart/I2C_EEPROM
 //
 // uses a 24LC256 (32KB) EEPROM
 // as this test writes a lot it might wear out EEPROMs eventually.
@@ -58,7 +59,7 @@ void test_1(int n)
   Serial.println(n);
   Serial.print("TEST:\twriteBlock()");
   delay(10);
-  ee.setBlock(0, 0, 100);  // clear first 100 bytes
+  ee.setBlock(0, 0, 100);  //  clear first 100 bytes
   start = micros();
   for (int i = 0; i < n; i++) ee.writeBlock(0, ar, 100);
   dur1 = micros() - start;
@@ -77,7 +78,7 @@ void test_1(int n)
 
   Serial.print("TEST:\tupdateBlock()");
   delay(10);
-  ee.setBlock(0, 0, 100);  // clear first 100 bytes
+  ee.setBlock(0, 0, 100);  //  clear first 100 bytes
   start = micros();
   for (int i = 0; i < n; i++) ee.updateBlock(0, ar, 100);
   dur1 = micros() - start;
@@ -92,7 +93,7 @@ void test_2()
 {
   Serial.println("\nTEST: 100x writeBlock()");
   delay(10);
-  ee.setBlock(0, 0, 100);  // clear first 100 bytes
+  ee.setBlock(0, 0, 100);  //  clear first 100 bytes
   start = micros();
   for (int i = 0; i < 100; i++)
   {
@@ -106,7 +107,7 @@ void test_2()
 
 
   Serial.println("\nTEST: 100x updateBlock()");
-  ee.setBlock(0, 0, 100);  // clear first 100 bytes
+  ee.setBlock(0, 0, 100);  //  clear first 100 bytes
   start = micros();
   for (int i = 0; i < 100; i++)
   {
@@ -122,7 +123,7 @@ void test_2()
 
 void dump(uint32_t from, uint32_t to)
 {
-  for (uint32_t i = from; i < to; i++)  // I2C_DEVICESIZE_24LC512
+  for (uint32_t i = from; i < to; i++)  //  I2C_DEVICESIZE_24LC512
   {
     char buffer[24];
     if (i % 16 == 0)
@@ -143,5 +144,5 @@ void dump(uint32_t from, uint32_t to)
 }
 
 
-// -- END OF FILE --
+//  -- END OF FILE --
 

--- a/examples/I2C_eeprom_verify/I2C_eeprom_verify.ino
+++ b/examples/I2C_eeprom_verify/I2C_eeprom_verify.ino
@@ -2,6 +2,7 @@
 //    FILE: I2C_eeprom_verify.ino
 //  AUTHOR: Rob Tillaart
 // PURPOSE: demo I2C_EEPROM library - updateByte
+//     URL: https://github.com/RobTillaart/I2C_EEPROM
 //
 // uses a 24LC256 (32KB) EEPROM
 
@@ -38,7 +39,7 @@ void setup()
   Serial.println("\n");
   Serial.println("\nTEST: NN x writeByte()");
   delay(10);
-  ee.setBlock(0, 0, 100);  // clear first 100 bytes
+  ee.setBlock(0, 0, 100);  //  clear first 100 bytes
   start = micros();
   for (int i = 0; i < NN; i++)
   {
@@ -51,7 +52,7 @@ void setup()
 
   Serial.println("\nTEST: NN x writeByteVerify()");
   delay(10);
-  ee.setBlock(0, 0, 100);  // clear first 100 bytes
+  ee.setBlock(0, 0, 100);  //  clear first 100 bytes
   start = micros();
   for (int i = 0; i < NN; i++)
   {
@@ -96,7 +97,7 @@ void setup()
 
   Serial.println("\nTEST: NN x updateByteVerify() not same data");
   delay(10);
-  ee.setBlock(0, 0, 100);  // clear first 100 bytes
+  ee.setBlock(0, 0, 100);  //  clear first 100 bytes
   start = micros();
   for (int i = 0; i < NN; i++)
   {
@@ -129,7 +130,7 @@ void setup()
 
   Serial.println("\nTEST: NN x writeBlockVerify()");
   delay(10);
-  ee.setBlock(0, 0, 100);  // clear first 100 bytes
+  ee.setBlock(0, 0, 100);  //  clear first 100 bytes
   start = micros();
   for (int i = 0; i < NN; i++)
   {
@@ -176,7 +177,7 @@ void setup()
   strcpy(buffer, "98765432109876543210987654321098765432109876543210");  //  50 bytes
   Serial.println("\nTEST: NN x updateBlockVerify() not same data");
   delay(10);
-  ee.setBlock(0, 0, 100);  // clear first 100 bytes
+  ee.setBlock(0, 0, 100);  //  clear first 100 bytes
   start = micros();
   for (int i = 0; i < NN; i++)
   {
@@ -194,7 +195,7 @@ void setup()
 
   Serial.println("\nTEST: NN x setBlock() same data");
   delay(10);
-  ee.setBlock(0, 0, 100);  // clear first 100 bytes
+  ee.setBlock(0, 0, 100);  //  clear first 100 bytes
   start = micros();
   for (int i = 0; i < NN; i++)
   {
@@ -207,7 +208,7 @@ void setup()
 
   Serial.println("\nTEST: NN x setBlockVerify() same data");
   delay(10);
-  ee.setBlock(0, 0, 100);  // clear first 100 bytes
+  ee.setBlock(0, 0, 100);  //  clear first 100 bytes
   start = micros();
   for (int i = 0; i < NN; i++)
   {
@@ -245,4 +246,4 @@ void loop()
 }
 
 
-// -- END OF FILE --
+//  -- END OF FILE --

--- a/examples/I2C_eeprom_verifyBlock/I2C_eeprom_verifyBlock.ino
+++ b/examples/I2C_eeprom_verifyBlock/I2C_eeprom_verifyBlock.ino
@@ -2,6 +2,7 @@
 //    FILE: I2C_eeprom_verifyBlock.ino
 //  AUTHOR: Rob Tillaart
 // PURPOSE: demo I2C_EEPROM library
+//     URL: https://github.com/RobTillaart/I2C_EEPROM
 //
 // uses a 24LC256 (32KB) EEPROM
 

--- a/examples/I2C_small_eeprom_test/I2C_small_eeprom_test.ino
+++ b/examples/I2C_small_eeprom_test/I2C_small_eeprom_test.ino
@@ -3,6 +3,7 @@
 //  AUTHOR: Tyler Freeman
 // VERSION: 0.1.1
 // PURPOSE: show/test I2C_EEPROM library with small EEPROMS
+//     URL: https://github.com/RobTillaart/I2C_EEPROM
 // HISTORY
 // 0.1.0    2014-05-xx initial version
 // 0.1.1    2020-07-14 fix #1 compile for ESP; fix author

--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "https://github.com/RobTillaart/I2C_EEPROM.git"
   },
-  "version": "1.8.3",
+  "version": "1.8.4",
   "license": "MIT",
   "frameworks": "*",
   "platforms": "*",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=I2C_EEPROM
-version=1.8.3
+version=1.8.4
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library for I2C EEPROMS


### PR DESCRIPTION
See discussion #69 

To support boards that can have "huge" I2C buffers > 255 bytes.